### PR TITLE
Rate to timeout

### DIFF
--- a/api/sphactor.api
+++ b/api/sphactor.api
@@ -41,24 +41,26 @@
         <argument name = "name" type = "string" />
     </method>
 
-    <method name = "set rate">
-        Set the iteration rate of this sphactor node. For example "60" runs 
-        the method of the actor 60 times per second. Note that the 
-        method receives a NULL message if it is triggered by timed event 
-        as opposed to when triggered by a socket event.
-        <argument name = "rate" type = "real" size="4" />
+    <method name = "set timeout">
+        Set the timeout of this sphactor node. This is used for the timeout 
+        of the poller so the sphactor is looped for a fixed interval. Note
+        that the sphactor's method receives a NULL message if it is 
+        triggered by timeout event as opposed to when triggered by a socket 
+        event. By default the timeout is -1 implying it never timeouts.
+        <argument name = "timeout" type = "msecs" />
     </method>
 
-    <method name = "get rate">
-        Return the current rate of this sphactor node. By default the rate is -1 
-        which means only triggers on socket events.
-        <return type = "real" size = "4" />
+    <method name = "get timeout">
+        Return the current timeout of this sphactor node's poller. By default 
+        the timeout is -1 which means it never times out but only triggers 
+        on socket events.
+        <return type = "msecs" />
     </method>
 
     <method name = "connect">
         Connect the node's sub socket to a pub endpoint. Returns 0 if succesful -1 on
         failure.
-	<argument name = "endpoint" type="string" />
+        <argument name = "endpoint" type="string" />
         <return type = "integer" />
     </method>
 

--- a/include/sphactor.h
+++ b/include/sphactor.h
@@ -62,17 +62,19 @@ SPHACTOR_EXPORT const char *
 SPHACTOR_EXPORT void
     sphactor_set_name (sphactor_t *self, const char *name);
 
-//  Set the iteration rate of this sphactor node. For example "60" runs
-//  the method of the actor 60 times per second. Note that the
-//  method receives a NULL message if it is triggered by timed event
-//  as opposed to when triggered by a socket event.
+//  Set the timeout of this sphactor node. This is used for the timeout
+//  of the poller so the sphactor is looped for a fixed interval. Note
+//  that the sphactor's method receives a NULL message if it is
+//  triggered by timeout event as opposed to when triggered by a socket
+//  event. By default the timeout is -1 implying it never timeouts.
 SPHACTOR_EXPORT void
-    sphactor_set_rate (sphactor_t *self, float rate);
+    sphactor_set_timeout (sphactor_t *self, int64_t timeout);
 
-//  Return the current rate of this sphactor node. By default the rate is -1
-//  which means only triggers on socket events.
-SPHACTOR_EXPORT float
-    sphactor_get_rate (sphactor_t *self);
+//  Return the current timeout of this sphactor node's poller. By default
+//  the timeout is -1 which means it never times out but only triggers
+//  on socket events.
+SPHACTOR_EXPORT int64_t
+    sphactor_get_timeout (sphactor_t *self);
 
 //  Connect the node's sub socket to a pub endpoint. Returns 0 if succesful -1 on
 //  failure.

--- a/src/sphactor_node.c
+++ b/src/sphactor_node.c
@@ -36,7 +36,7 @@ struct _sphactor_node_t {
     char        *name;            //  Our name (defaults to first 6 chars of our uuid)
     zhash_t     *subs;            //  a list of our subscription sockets
     zloop_t     *loop;            //  perhaps we'll use zloop instead of poller
-    int         timeout;          //  timeout to wait on polling. Indirect rate for calling the handler
+    int64_t     timeout;          //  timeout to wait on polling. Indirect rate for calling the handler
     sphactor_handler_fn *handler; //  the handler to call on events
     void        *handler_args;    //  the arguments to the handler
 //    sphactor_shim_t *shim;
@@ -272,15 +272,15 @@ sphactor_node_recv_api (sphactor_node_t *self)
     if (streq (command, "SET VERBOSE"))
         self->verbose = true;
     else
-    if (streq (command, "SET RATE"))
+    if (streq (command, "SET TIMEOUT"))
     {
         char *rate =  zmsg_popstr(request);
         //  rate is per second, timeout is in ms
-        self->timeout = 1000./(float) atof(rate);
+        self->timeout = (int64_t) atol(rate);
     }
     else
-    if (streq (command, "RATE"))
-        zstr_sendf(self->pipe, "%.1f", self->timeout == -1 ? self->timeout : 62.5);
+    if (streq (command, "TIMEOUT"))
+        zstr_sendf(self->pipe, "%i", self->timeout);
     else
     if (streq (command, "$TERM"))
         //  The $TERM command is send by zactor_destroy() method
@@ -598,15 +598,14 @@ sphactor_node_test (bool verbose)
     zactor_t *sphactor_rate_tester = zactor_new (sphactor_node_actor, &rate_tester);
     assert(sphactor_rate_tester);
     int64_t start = zclock_mono();
-    zstr_send(sphactor_rate_tester, "RATE");
-    zclock_sleep(1000/60);
+    zstr_send(sphactor_rate_tester, "TIMEOUT");
     char *ret = zstr_recv(sphactor_rate_tester);
-    assert( streq( ret, "-1.0") );
-    zstr_sendm(sphactor_rate_tester, "SET RATE");
-    zstr_send(sphactor_rate_tester, "60");
-    zstr_send(sphactor_rate_tester, "RATE");
+    assert( streq( ret, "-1") );
+    zstr_sendm(sphactor_rate_tester, "SET TIMEOUT");
+    zstr_send(sphactor_rate_tester, "16");
+    zstr_send(sphactor_rate_tester, "TIMEOUT");
     ret = zstr_recv(sphactor_rate_tester);
-    assert( streq( ret, "62.5") );
+    assert( streq( ret, "16") );
     zstr_free(&ret);
     zclock_sleep(1000/60);
     zactor_destroy (&sphactor_rate_tester);


### PR DESCRIPTION
The rate method is a bit inconvenient since the poller uses a timeout value. Thus we need to calculate the timeout from the rate. But when requesting the rate we then need to calculate the rate from the timeout. This is not possible with integers. Therefore we switch to using the timeout directly.