### PR TITLE
Added sphactor_send_msg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 2.8.12)
 project(libsphactor)
 enable_language(C)
 enable_testing()
@@ -25,7 +25,7 @@ set(pkg_config_names_private "")
 ########################################################################
 # options
 ########################################################################
-if (NOT CMAKE_BUILD_TYPE) 
+if (NOT CMAKE_BUILD_TYPE)
     if (EXISTS "${SOURCE_DIR}/.git")
         set (CMAKE_BUILD_TYPE Debug)
     else ()
@@ -215,7 +215,7 @@ if (SPHACTOR_BUILD_SHARED)
     IF (MSVC)
       add_library(sphactor SHARED ${sphactor_sources})
     ELSE (MSVC)
-     add_library(sphactor SHARED $<TARGET_OBJECTS:sphactor_objects>)
+      add_library(sphactor SHARED $<TARGET_OBJECTS:sphactor_objects>)
     ENDIF (MSVC)
   ENDIF(APPLE)
 
@@ -223,7 +223,7 @@ if (SPHACTOR_BUILD_SHARED)
     PUBLIC_HEADER "${public_headers}"
     DEFINE_SYMBOL "SPHACTOR_EXPORTS"
     SOVERSION "0"
-    VERSION "${SPHACTOR_VERSION}"
+	VERSION "${SPHACTOR_VERSION}"
     COMPILE_DEFINITIONS "DLL_EXPORT"
     OUTPUT_NAME "sphactor"
     PREFIX "lib"
@@ -249,11 +249,15 @@ endif()
 
 # static
 if (SPHACTOR_BUILD_STATIC)
-  #IF (MSVC)
+  IF (APPLE)
     add_library(sphactor-static STATIC ${sphactor_sources})
-  #ELSE (MSVC)
-  #  add_library(sphactor-static STATIC $<TARGET_OBJECTS:sphactor_objects>)
-  #ENDIF (MSVC)
+  ELSE (APPLE)
+    IF (MSVC)
+      add_library(sphactor-static STATIC ${sphactor_sources})
+    ELSE (MSVC)
+      add_library(sphactor-static STATIC $<TARGET_OBJECTS:sphactor_objects>)
+    ENDIF (MSVC)
+  ENDIF (APPLE)
 
   set_target_properties(sphactor-static PROPERTIES
     PUBLIC_HEADER "${public_headers}"

--- a/api/sphactor.api
+++ b/api/sphactor.api
@@ -110,6 +110,11 @@
         <return type = "zsock" />
     </method>
 
+    <method name = "send msg">
+        Sends a passed message to the actor's pub socket. 
+        <argument name = "msg" type = "zmsg" />
+    </method>
+
     <method name = "set verbose">
         Set the verbosity of the node. 
         <argument name = "on" type = "boolean" />

--- a/include/sphactor.h
+++ b/include/sphactor.h
@@ -115,6 +115,10 @@ SPHACTOR_EXPORT int
 SPHACTOR_EXPORT zsock_t *
     sphactor_socket (sphactor_t *self);
 
+//  Sends a passed message to the actor's pub socket.
+SPHACTOR_EXPORT void
+    sphactor_send_msg (sphactor_t *self, zmsg_t *msg);
+
 //  Set the verbosity of the node.
 SPHACTOR_EXPORT void
     sphactor_set_verbose (sphactor_t *self, bool on);

--- a/src/sphactor.c
+++ b/src/sphactor.c
@@ -216,6 +216,14 @@ sphactor_socket(sphactor_t *self)
 }
 
 void
+sphactor_send_msg (sphactor_t *self, zmsg_t *msg)
+{
+    zsock_t* socket = sphactor_socket(self);
+    zstr_send(socket, "SEND MSG");
+    zmsg_send(&msg, socket);
+}
+
+void
 sphactor_set_verbose (sphactor_t *self, bool on)
 {
     assert (self);

--- a/src/sphactor_node.c
+++ b/src/sphactor_node.c
@@ -238,6 +238,20 @@ sphactor_node_recv_api (sphactor_node_t *self)
         zstr_free(&dest);
     }
     else
+    if (streq (command, "SEND MSG"))
+    {
+        zmsg_t* incoming = zmsg_recv(self->pipe);
+        if ( incoming ) {
+            // publish the msg
+            zmsg_send(&incoming, self->pub);
+            
+            // delete message if we have no connections (otherwise it leaks)
+            if ( zsock_endpoint(self->pub) == NULL ) {
+                zmsg_destroy(&incoming);
+            }
+        }
+    }
+    else
     if (streq (command, "UUID"))
     {
         zsock_send(self->pipe, "U", self->uuid);


### PR DESCRIPTION
I created this from an OSCListener use-case, where I had a thread poller outside of sphactor that was giving me OSC, that I packed into zmsg_t, and wanted to publish from the actor. I thought it was inconvenient to require code outside of the sphactor codebase to have knowledge about the node function strings, so I wrapped it in an API function.

It basically works like the regular SEND command, but for messages.