### PR TITLE
Added sphactor dispose

### DIFF
--- a/api/sphactor.api
+++ b/api/sphactor.api
@@ -22,6 +22,10 @@
         <return type = "zlist"/>
     </method>
 
+    <method name = "dispose" singleton = "1">
+        <return type = "nothing"/>
+    </method>
+
     <constructor>
         Constructor, creates a new Sphactor node. 
         <argument name = "handler" type = "sphactor_handler_fn" callback = "1" />

--- a/include/sphactor.h
+++ b/include/sphactor.h
@@ -61,6 +61,10 @@ SPHACTOR_EXPORT int
 SPHACTOR_EXPORT zlist_t *
     sphactor_get_registered (void);
 
+//
+SPHACTOR_EXPORT void
+    sphactor_dispose (void);
+
 //  Return our sphactor's UUID string, after successful initialization
 SPHACTOR_EXPORT zuuid_t *
     sphactor_uuid (sphactor_t *self);

--- a/src/sphactor.c
+++ b/src/sphactor.c
@@ -38,6 +38,7 @@ struct _sphactor_t {
 
 //  Hash table for the actor_type register of actors
 static zhash_t *actors_reg = NULL;
+static zlist_t *actors_keys = NULL;
 
 //  --------------------------------------------------------------------------
 //  Create a new sphactor. Pass a name and uuid. If your specify NULL
@@ -299,7 +300,13 @@ zlist_t *
 sphactor_get_registered ()
 {
     if ( actors_reg == NULL ) actors_reg = zhash_new();
-    return zhash_keys(actors_reg);
+    
+    if ( actors_keys != NULL ) {
+        zlist_destroy(&actors_keys);
+    }
+    
+    actors_keys = zhash_keys(actors_reg);
+    return actors_keys;
 }
 
 //  --------------------------------------------------------------------------

--- a/src/sphactor.c
+++ b/src/sphactor.c
@@ -309,6 +309,17 @@ sphactor_get_registered ()
     return actors_keys;
 }
 
+//
+//  Disposes of all statically allocated resources
+//   Call this before shutting down, because otherwise these resources will be re-allocated as needed.
+void
+sphactor_dispose ()
+{
+    zlist_destroy(&actors_keys);
+    zhash_destroy(&actors_reg);
+}
+
+
 //  --------------------------------------------------------------------------
 //  Self test of this class
 


### PR DESCRIPTION
sphactor maintains a static hash of actors and subsequent zlist of keys, which need to be disposed at application termination. New function sphactor_dispose() takes care of this.